### PR TITLE
docs/DevOps-73.1/adicionando-pr-no-SinaraApi

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Descrição do PR
+- [ ] Novos endpoints ou controllers
+- [ ] Correção de endpoints existentes
+- [ ] Ajustes de lógica de negócio
+
+## Issue Relacionada
+Resolve <a href="link-da-tarefa-57">#57</a>
+
+## Como testar
+1. Rodar a aplicação
+2. Testar endpoints via Postman ou Swagger
+3. Conferir logs e respostas corretas
+
+## Checklist
+- [ ] Testes unitários cobrindo alterações
+- [ ] Testes de integração rodando
+- [ ] Migrações de banco aplicadas (se houver)
+- [ ] Build e CI passando
+- [ ] Documentação da API atualizada
+
+## Observações
+<!-- Não obrigatório -->


### PR DESCRIPTION
### Descrição
Este PR adiciona o template definitivo de Pull Request no repositório, dentro da pasta .github/PULL_REQUEST_TEMPLATE.md.
O objetivo é padronizar a forma como PRs são abertos, garantindo consistência, clareza e facilitando o processo de revisão de código.

### Motivação
Atualmente, cada desenvolvedor pode escrever PRs de maneiras diferentes, o que dificulta a revisão e o acompanhamento histórico.
Com este template:
- Revisores terão uma checklist clara do que precisa ser validado
- Autores de PR terão um guia pronto para descrever suas mudanças
- O time ganha em organização e velocidade de revisão

### Mudanças incluídas
- Criação da pasta .github/ (se não existir)
- Adição do arquivo PULL_REQUEST_TEMPLATE.md com o conteúdo definitivo

### Como testar
- Fazer checkout desta branch
- Criar um novo Pull Request de teste
- Verificar se o corpo do PR é preenchido automaticamente com o template

### Checklist
[X] Template de PR criado
[X] Estrutura .github/ configurada
[X] Testado localmente (preview do PR carregando corretamente)

### Observações
A partir de agora, todo novo PR seguirá o modelo que estou subindo nessa PR.